### PR TITLE
Replaced deprecated curly braces for php 7.4

### DIFF
--- a/SxGeo.php
+++ b/SxGeo.php
@@ -232,7 +232,7 @@ class SxGeo
         $pos = 0;
         foreach ($pack as $p) {
             list($type, $name) = explode(':', $p);
-            $type0 = $type{0};
+            $type0 = $type[0];
             if ($empty) {
                 $unpacked[$name] = $type0 == 'b' || $type0 == 'c' ? '' : 0;
                 continue;
@@ -278,7 +278,7 @@ class SxGeo
                     $v = unpack('S', $val);
                     break;
                 case 'm':
-                    $v = unpack('l', $val . (ord($val{2}) >> 7 ? "\xff" : "\0"));
+                    $v = unpack('l', $val . (ord($val[2]) >> 7 ? "\xff" : "\0"));
                     break;
                 case 'M':
                     $v = unpack('L', $val . "\0");
@@ -297,10 +297,10 @@ class SxGeo
                     break;
 
                 case 'n':
-                    $v = current(unpack('s', $val)) / pow(10, $type{1});
+                    $v = current(unpack('s', $val)) / pow(10, $type[1]);
                     break;
                 case 'N':
-                    $v = current(unpack('l', $val)) / pow(10, $type{1});
+                    $v = current(unpack('l', $val)) / pow(10, $type[1]);
                     break;
 
                 case 'c':


### PR DESCRIPTION
I replaced deprecated curly braces for PHP 7.4
[see here](https://www.php.net/manual/en/migration74.deprecated.php#migration74.deprecated.core.array-string-access-curly-brace)